### PR TITLE
Allow multi site support

### DIFF
--- a/src/fields/Donkeytail.php
+++ b/src/fields/Donkeytail.php
@@ -415,7 +415,7 @@ class Donkeytail extends Field
         $meta = [];
         if ($findPins == true && $value['pinIds'] && is_array($value['pinIds'])) {
             foreach ($value['pinIds'] as $pinId) {
-                $pinElement = Craft::$app->getElements()->getElementById($pinId, $pinElementType);
+                $pinElement = Craft::$app->getElements()->getElementById($pinId, $pinElementType, '*');
                 if ($pinElement) {
                     // If element exists, show it
                     array_push($pinElements, $pinElement);

--- a/src/templates/_components/fields/Donkeytail_input.twig
+++ b/src/templates/_components/fields/Donkeytail_input.twig
@@ -66,6 +66,7 @@
             criteria: {
               'enabledForSite': null,
             },
+            showSiteMenu: true,
             sources: pinElementSources,
             jsClass: 'Craft.BaseElementSelectInput',
             selectionLabel: "Add #{pinElementType|split('\\')|last}" |t,


### PR DESCRIPTION
This fixes https://github.com/simplygoodwork/craft-donkeytail/issues/22

When site menu is enabled, by default the correct site is selected in craft.
In order to fix the view, we need to search for the element over all sites (hence the `*`)