### PR TITLE
#27 fetch pins in same order as field

### DIFF
--- a/src/models/DonkeytailModel.php
+++ b/src/models/DonkeytailModel.php
@@ -96,7 +96,7 @@ class DonkeytailModel extends Model
     }
 
     /**
-     * Get the URL to the canvas asset 
+     * Get the URL to the canvas asset
      *
      * @param null $transform
      *
@@ -120,7 +120,7 @@ class DonkeytailModel extends Model
     }
 
     public function getPins()
-    {   
+    {
         $pins = [];
 
         $elementTypeClass = $this->getPinsElementType();
@@ -128,7 +128,8 @@ class DonkeytailModel extends Model
 
         $query = $elementTypeClass::find();
         $criteria = [
-            'id' => $this->pinIds
+            'id' => $this->pinIds,
+            'fixedOrder' => true
         ];
         Craft::configure($query, $criteria);
         $queryAll = $query->all();


### PR DESCRIPTION
Fixes #27 

Gets pins in the same order they are arranged with the field. Required for use case in #27 where 'pin' data is also displayed in a list, rather than just pins on a canvas.

Tested with assets, entries, users, via Twig and GraphQL.