### PR TITLE
Real multi-site support!

### DIFF
--- a/src/fields/Donkeytail.php
+++ b/src/fields/Donkeytail.php
@@ -126,11 +126,15 @@ class Donkeytail extends Field
      */
     public function normalizeValue($value, ElementInterface $element = null)
     {
+        $site = ($element ? $element->getSite() : Craft::$app->getSites()->getCurrentSite());
+
         if (is_string($value) && !empty($value)) {
             $value = Json::decode($value);
         }
 
+        $value['site'] = $site;
         $model = new DonkeytailModel($value);
+
         return $model;
     }
 
@@ -146,7 +150,10 @@ class Donkeytail extends Field
      */
     public function serializeValue($value, ElementInterface $element = null)
     {
-        return parent::serializeValue($value, $element);
+        $_serialized = parent::serializeValue($value, $element);
+        unset($_serialized['site']);
+
+        return $_serialized;
     }
 
     /**
@@ -381,6 +388,7 @@ class Donkeytail extends Field
 
         $id = Html::id($this->handle);
         $namespacedId = $view->namespaceInputId($id);
+        $site = ($element ? $element->getSite() : Craft::$app->getSites()->getCurrentSite());
 
         $csrf = Craft::$app->request->csrfToken;
         $view->registerJs("window.csrfToken = '$csrf';", $view::POS_HEAD);
@@ -415,14 +423,14 @@ class Donkeytail extends Field
         $meta = [];
         if ($findPins == true && $value['pinIds'] && is_array($value['pinIds'])) {
             foreach ($value['pinIds'] as $pinId) {
-                $pinElement = Craft::$app->getElements()->getElementById($pinId, $pinElementType);
+                $pinElement = Craft::$app->getElements()->getElementById($pinId, $pinElementType, $site->id);
                 if ($pinElement) {
                     // If element exists, show it
                     array_push($pinElements, $pinElement);
-                    
+
                     // Ensure label for pin element is up to date
                     if ($this->pinElementType == 'User') {
-                        $value->meta[$pinElement->id]['label'] = $pinElement->username; 
+                        $value->meta[$pinElement->id]['label'] = $pinElement->username;
                     } else {
                         $value->meta[$pinElement->id]['label'] = $pinElement->title;
                     }
@@ -446,6 +454,7 @@ class Donkeytail extends Field
                 'id' => $id,
                 'namespacedId' => $namespacedId,
                 'element' => $element,
+                'site' => $site->handle,
 
                 'canvasSourceExists' => count(Craft::$app->getAssets()->findFolders()),
                 'canvasElements' => $canvasElements,

--- a/src/models/DonkeytailModel.php
+++ b/src/models/DonkeytailModel.php
@@ -39,7 +39,14 @@ class DonkeytailModel extends Model
     /**
      * Some model attribute
      *
-     * @var array
+     * @var string
+     */
+    public $site = "";
+
+    /**
+     * Some model attribute
+     *
+     * @var string
      */
     public $canvasId = "";
 
@@ -129,6 +136,7 @@ class DonkeytailModel extends Model
         $query = $elementTypeClass::find();
         $criteria = [
             'id' => $this->pinIds,
+            'site' => $this->site->handle,
             'fixedOrder' => true
         ];
         Craft::configure($query, $criteria);

--- a/src/templates/_components/fields/Donkeytail_input.twig
+++ b/src/templates/_components/fields/Donkeytail_input.twig
@@ -27,7 +27,7 @@
   {% endif %}
 
   {# NOTE: Drag'n'drop onto this does not work: https://github.com/craftcms/cms/issues/3024 #}
-  {{ 
+  {{
     forms.elementSelectField({
       elements: canvasElement,
       id: id ~ '-canvasId',
@@ -35,8 +35,9 @@
       label: '' |t,
       elementType: canvasElementType,
       criteria: {
-      'kind': [],
-      'enabledForSite': null,
+        'kind': [],
+        'enabledForSite': null,
+        'site': site
       },
       sources: canvasSources,
       jsClass: 'Craft.AssetSelectInput',
@@ -56,7 +57,7 @@
   <div id="{{ id }}-pane" class="pane flex flex-wrap items-start overflow-hidden 2xl:!flex-no-wrap" {{ value.canvasId|length or autoSelected ? : "style='height: 0; opacity: 0; padding: 0;'" }}>
     <div>
       {% if pinElementSources|length %}
-        {{ 
+        {{
           forms.elementSelectField({
             elements: (pinElements is defined and pinElements ? [pinElements][0]),
             id: id ~ '-pins',
@@ -65,6 +66,7 @@
             elementType: pinElementType,
             criteria: {
               'enabledForSite': null,
+              'site': site
             },
             sources: pinElementSources,
             jsClass: 'Craft.BaseElementSelectInput',


### PR DESCRIPTION
Hi, i found myself in a situation which requires the support of localized pin entries. 

I saw [this PR](https://github.com/simplygoodwork/craft-donkeytail/pull/25) three hours ago (and it got merged after 3 months right when i checked it out!!), but I found out that with this modification alone, associating a multi-site entry to a canvas always returned the one associated with the default site. 

I worked out a better solution which checks the locale of the current element and retrieves the localized version of entries in the control panel, then also adds the site reference in the query which fetches the entries, thus adding real multi site support to the field. 

I need this functionality in a project so i hope it gets merged soon :)