### PR TITLE
Use site ID instead of handle

### DIFF
--- a/src/models/DonkeytailModel.php
+++ b/src/models/DonkeytailModel.php
@@ -136,7 +136,7 @@ class DonkeytailModel extends Model
         $query = $elementTypeClass::find();
         $criteria = [
             'id' => $this->pinIds,
-            'site' => $this->site->handle,
+            'siteId' => $this->site->id,
             'fixedOrder' => true
         ];
         Craft::configure($query, $criteria);


### PR DESCRIPTION
When attempting to load pins in preview-mode for a disabled site using the site handle in the query, Craft tries to resolve the Site object with a query that excludes disabled sites. This results in no site being found and an error being thrown. When using the site ID instead, Craft finds the site just fine, so the query works as expected.